### PR TITLE
Fixed wrong keyboard on iPhone and crasher with long text

### DIFF
--- a/FormKit/FKFormAttributeMapping.m
+++ b/FormKit/FKFormAttributeMapping.m
@@ -70,10 +70,11 @@
     
     if (FKFormAttributeMappingTypeFloat == type) {
         self.keyboardType = UIKeyboardTypeDecimalPad;
-        
     } else if (FKFormAttributeMappingTypeInteger == type) {
         self.keyboardType = UIKeyboardTypeNumberPad;
         
+    } else {
+        self.keyboardType = UIKeyboardTypeDefault;
     }
 }
 

--- a/Vendor/BWLongTextViewController/BWLongTextViewController.m
+++ b/Vendor/BWLongTextViewController/BWLongTextViewController.m
@@ -86,6 +86,12 @@
 //    self.textView = nil;
 }
 
+- (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear:animated];
+    
+    [self.textView resignFirstResponder];
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {


### PR DESCRIPTION
Two smaller fixes, see the commit messages for more details.
