### PR TITLE
NSNumber fields that represent YES/NO values with FKSwitchField controls weren't getting saved

### DIFF
--- a/FormKit/FKFormMapper.m
+++ b/FormKit/FKFormMapper.m
@@ -246,7 +246,7 @@
         [(FKTextField *)field textField].text = convertedValue;
         [(FKTextField *)field textField].placeholder = attributeMapping.placeholderText;
         
-    } else if ([field isKindOfClass:[FKSwitchField class]] && [convertedValue isKindOfClass:[NSNumber class]]) {
+    } else if ([field isKindOfClass:[FKSwitchField class]]) {
         UISwitch *switchControl = [(FKSwitchField *)field switchControl];
         switchControl.on = [(NSNumber *)convertedValue boolValue];
         switchControl.formAttributeMapping = attributeMapping;


### PR DESCRIPTION
 Removed NSNumber check for FKSwitchField because attributes that start out as nil don't convert to NSNumber, but are instead nil
