### PR TITLE
Cell height calculation fix (iOS8 compatibility)

### DIFF
--- a/FormKit/FKFormMapper.m
+++ b/FormKit/FKFormMapper.m
@@ -655,6 +655,9 @@
     }
     
     CGFloat rowHeight = attributeMapping.rowHeight > 0 ? attributeMapping.rowHeight : self.tableView.rowHeight;
+    if (rowHeight == UITableViewAutomaticDimension) {
+        rowHeight = 44;
+    }
     
     if ([self.formModel.invalidAttributes containsObject:attributeMapping.attribute] &&
         nil != attributeValidation.errorMessageBlock) {

--- a/FormKit/FKFormMapper.m
+++ b/FormKit/FKFormMapper.m
@@ -655,9 +655,6 @@
     }
     
     CGFloat rowHeight = attributeMapping.rowHeight > 0 ? attributeMapping.rowHeight : self.tableView.rowHeight;
-    if (rowHeight == UITableViewAutomaticDimension) {
-        rowHeight = 44;
-    }
     
     if ([self.formModel.invalidAttributes containsObject:attributeMapping.attribute] &&
         nil != attributeValidation.errorMessageBlock) {
@@ -665,6 +662,9 @@
         Class<FKFieldErrorProtocol> cellClass = [self cellClassWithAttributeMapping:attributeMapping];
         id value = [self valueForAttributeMapping:attributeMapping];
         
+        if (rowHeight == UITableViewAutomaticDimension) {
+            rowHeight = 44;
+        }
         rowHeight += [cellClass errorHeightWithError:attributeValidation.errorMessageBlock(value, self.object)
                                            tableView:self.tableView];
     }


### PR DESCRIPTION
This is the second part of iOS 8 fixes, related to the table view rowHeight property returns UITableViewAutomaticDimension ( == -1) on iOS 8. This causes issues when the (not custom) cell had an error message.

Cheers
